### PR TITLE
Add CI smoke test: boot --app mode against a stock Platform checkout

### DIFF
--- a/.github/workflows/smoke-app-mode.yml
+++ b/.github/workflows/smoke-app-mode.yml
@@ -1,0 +1,48 @@
+name: smoke — app mode
+
+# Boots the server the way the README documents for Qbix apps, against a stock
+# Qbix Platform checkout, and asserts it answers one request.
+#
+# No database, no installed plugins, no configuration beyond what
+# Platform/MyApp ships: the whole fixture is `cp -r local.sample local`, point
+# paths.json at platform/, and drop the "localNotYetConfigured" marker.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  app-mode:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the webserver
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          # pcntl is what makes the fork-after-preload path run at all; without
+          # it the server silently falls back to subprocess mode.
+          extensions: pcntl, sockets
+
+      - name: Check out Qbix Platform
+        uses: actions/checkout@v4
+        with:
+          repository: Qbix/Platform
+          path: Platform
+          # Submodules are the plugins; the smoke test does not need them.
+          submodules: false
+
+      - name: Scaffold a stock app
+        run: |
+          cd Platform
+          cp -r MyApp/local.sample MyApp/local
+          printf '{"platform": "%s/platform"}\n' "$PWD" > MyApp/local/paths.json
+          # Platform refuses to boot while this marker is present.
+          sed -i '/localNotYetConfigured/d' MyApp/local/app.json
+
+      - name: Boot --app mode against it
+        run: APP_DIR="$PWD/Platform/MyApp" tests/smoke-app-mode.sh

--- a/tests/smoke-app-mode.sh
+++ b/tests/smoke-app-mode.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Smoke test: does `--app` mode actually boot against a stock Qbix Platform app?
+#
+# This is deliberately the smallest possible assertion. It does not check that
+# the app renders, or that routing works, or that anything is fast. It starts
+# the server the way the README documents for Qbix apps, waits, and asks for
+# one URL the server serves itself:
+#
+#     php qbixserver.php --app=<app> --port=<port>   →   GET /Q/health == 200
+#
+# If the server dies during bootstrap, or never binds, the test fails and
+# prints the server's output.
+#
+# Usage:
+#   APP_DIR=/path/to/Platform/MyApp tests/smoke-app-mode.sh
+#
+# Environment:
+#   APP_DIR   (required) a Qbix Platform app directory — one with
+#             scripts/Q.inc.php and local/paths.json
+#   PORT      (default 8079)
+#   TIMEOUT   (default 20) seconds to wait for the server to answer
+#   PHP       (default php)
+
+set -uo pipefail
+
+APP_DIR=${APP_DIR:-}
+PORT=${PORT:-8079}
+TIMEOUT=${TIMEOUT:-20}
+PHP=${PHP:-php}
+
+if [ -z "$APP_DIR" ]; then
+	echo "smoke-app-mode: APP_DIR is required" >&2
+	exit 2
+fi
+if [ ! -f "$APP_DIR/scripts/Q.inc.php" ]; then
+	echo "smoke-app-mode: $APP_DIR does not look like a Qbix app (no scripts/Q.inc.php)" >&2
+	exit 2
+fi
+if [ ! -f "$APP_DIR/local/paths.json" ]; then
+	echo "smoke-app-mode: $APP_DIR/local/paths.json missing — run scripts/Q/configure.php" >&2
+	exit 2
+fi
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+
+echo "smoke-app-mode: starting qbixserver.php --app=$APP_DIR --port=$PORT"
+"$PHP" "$ROOT/qbixserver.php" --app="$APP_DIR" --port="$PORT" > "$LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup_server() {
+	if kill -0 "$SERVER_PID" 2>/dev/null; then
+		kill "$SERVER_PID" 2>/dev/null
+		wait "$SERVER_PID" 2>/dev/null
+	fi
+}
+
+fail() {
+	echo
+	echo "smoke-app-mode: FAIL — $1"
+	echo "──────── server output ────────"
+	cat "$LOG"
+	echo "───────────────────────────────"
+	cleanup_server
+	exit 1
+}
+
+deadline=$(( $(date +%s) + TIMEOUT ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+	if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+		wait "$SERVER_PID" 2>/dev/null
+		code=$?
+		# Note: a bootstrap fatal currently exits 0, so the exit code alone is
+		# not a reliable signal — the liveness check above is what catches it.
+		fail "the server process exited during startup (exit code $code)"
+	fi
+	if curl -fsS -o /dev/null "http://127.0.0.1:$PORT/Q/health" 2>/dev/null; then
+		echo "smoke-app-mode: PASS — /Q/health answered 200"
+		cleanup_server
+		exit 0
+	fi
+	sleep 0.5
+done
+
+fail "the server never answered /Q/health within ${TIMEOUT}s"


### PR DESCRIPTION
Adds one test and one workflow. The test starts the server the way the README
documents for Qbix apps and asserts that it answers a single request:

```
php qbixserver.php --app=<app> --port=<port>   →   GET /Q/health == 200
```

That is the whole assertion. Not rendering, not routing, not performance — only
that the process survives bootstrap and binds.

**It passes on `01e71a9`.** We verified it against a fresh `Qbix/Platform` clone
in a PHP 8.3 container with `pcntl` and `sockets`:

```
smoke-app-mode: starting qbixserver.php --app=/tmp/Platform/MyApp --port=8079
smoke-app-mode: PASS — /Q/health answered 200
```

## Why it is worth having

We have evaluated this server against a real Qbix Platform app four times
(2026-07-28, 07-31, 08-05, 08-06). `--app` mode failed to boot on the first
three, each time for a different reason at a slightly later line, and each time
the previous reason had been fixed correctly. `01e71a9` is the first ref where
it starts — thank you.

This test is the regression guard for that. On `fd97f5e` it fails with:

```
smoke-app-mode: FAIL — the server process exited during startup (exit code 0)
Error: Class "Q_WebServer" not found in qbixserver.php:408
```

which is #9, fixed by this commit. On `01e71a9` it passes. That is exactly the
transition worth pinning down, and it costs about a minute of CI.

## The fixture is genuinely stock

No database, no installed plugins, no configuration beyond what `Platform/MyApp`
already ships:

```bash
cp -r MyApp/local.sample MyApp/local
printf '{"platform": "%s/platform"}\n' "$PWD" > MyApp/local/paths.json
sed -i '/localNotYetConfigured/d' MyApp/local/app.json
```

Three lines. If `--app` mode ever needs more than that to start, this is where it
shows up.

## One note on the exit code

The test asserts on process liveness and a real HTTP response rather than on
`$?`, because a bootstrap fatal currently exits **0** — a server that never bound
a port is indistinguishable from a clean shutdown to any supervisor. That is a
separate issue and this PR does not address it; it just does not rely on the
exit code.

## Possible follow-up, not included here

Your `$webserverOwnedClasses` allowlist deliberately leaves `Q_Evented`,
`Q_Utils`, `Q_Uri` and `Q_Snapshot` to the Platform. That holds for Platform at
HEAD. Against an older Platform checkout that predates those classes, the server
dies at startup with `Class "Q_Evented" not found` (exit 0) even though it ships
its own `src/Q/Evented.php`. We hit this on our own vendored Platform and will
file it separately.

If that is worth guarding too, a second matrix leg pinning an older
`Qbix/Platform` ref would catch it. We left it out of this PR to keep the check
green and the change small — happy to add it if you would like it here instead.
