### PR TITLE
Fix $_SERVER on the preforked worker path (#14)

### DIFF
--- a/src/Q/WebServer/Pool.php
+++ b/src/Q/WebServer/Pool.php
@@ -417,6 +417,32 @@ class Q_WebServer_Pool
 			Q_Evented::enable($this->watchers[$index]);
 		}
 
+		// Issue #14: SCRIPT_NAME must keep its directory segments, and
+		// SERVER_PORT must come from the request rather than the listen port.
+		// Same normalisation as Q_WebServer::dispatchToQ(): realpath() both
+		// sides so a symlinked docroot cannot eat a segment.
+		$rootDir = Q_WebServer::$rootDir ?? '';
+		$docRoot = rtrim(realpath($rootDir) ?: $rootDir, DS);
+		$scriptReal = realpath($scriptPath) ?: $scriptPath;
+		if ($docRoot !== ''
+		and strncmp($scriptReal, $docRoot, strlen($docRoot)) === 0) {
+			$scriptName = '/' . ltrim(
+				str_replace(DS, '/', substr($scriptReal, strlen($docRoot))), '/'
+			);
+		} else {
+			$scriptName = '/' . basename($scriptPath);
+		}
+		// The master is a CLI process, so $_SERVER['SERVER_PORT'] is unset there
+		// and every worker used to receive the literal '8080'. Take the port
+		// from the Host header, falling back to the scheme default.
+		$hostParts = explode(':', $parsed['headers']['host'] ?? 'localhost');
+		if (isset($hostParts[1])) {
+			$serverPort = (string) $hostParts[1];
+		} else {
+			$scheme = $parsed['_scheme'] ?? 'http';
+			$serverPort = ($scheme === 'https') ? '443' : '80';
+		}
+
 		$msg = json_encode(array(
 			'method'         => $parsed['method'],
 			'uri'            => $parsed['uri'],
@@ -426,9 +452,9 @@ class Q_WebServer_Pool
 			'rawHeaders'     => $parsed['rawHeaders'] ?? array(),
 			'body'           => $parsed['body'],
 			'scriptFilename' => $scriptPath,
-			'scriptName'     => '/' . basename($scriptPath),
+			'scriptName'     => $scriptName,
 			'documentRoot'   => Q_WebServer::$rootDir ?? '',
-			'serverPort'     => (string)($_SERVER['SERVER_PORT'] ?? '8080'),
+			'serverPort'     => $serverPort,
 			'remoteAddr'     => '127.0.0.1'
 		));
 		$written = @fwrite($this->workers[$index]['socket'], pack('N', strlen($msg)) . $msg);


### PR DESCRIPTION
Follow-up to `f310515`, which fixed #14 at three call sites — `dispatchToQ()`, `handlePhpCgi()` and `handleRoute()`. `Q_WebServer_Pool::dispatch()` builds its own `$req` array and was missed, and that is the path taken for **every request whenever `--workers` is non-zero**, which is the default (4).

Two symptoms, both at `src/Q/WebServer/Pool.php:429`:

- `scriptName` used `basename($scriptPath)`, dropping every directory segment — `/Q/srv.php` arrived at the worker as `/srv.php`.
- `serverPort` read `$_SERVER['SERVER_PORT']` in the master, which is a CLI process where it is unset, so workers always received the literal `'8080'` regardless of the request.

Platform composes its base URL from both, rejects the request as `bad url`, then resolves the stray port as a path component (`Communities_Exception_NoSuchCommunity` in our app). The patch applies the same realpath-normalised stripping and Host-header-derived port the other three sites already use.

**Verified** against `Qbix/Platform` `c8766b5` with a real 9-plugin, 73-table app, apache on the identical tree as the control:

| probe on `/Q/srv.php` | before | after | apache |
|---|---|---|---|
| `SERVER_PORT` | `8080` | `80` | `80` |
| `SCRIPT_NAME` | `/srv.php` | `/Q/srv.php` | `/Q/srv.php` |
| `GET /` | 412, error route | **200, full page** | 200, full page |

Two notes so this is not oversold:

1. `--workers=0` was already correct at `f310515` — this only brings the pool path in line with it.
2. `GET /` still returns a short body on a minority of requests (4 of 12 above). That is #16, which I have re-opened separately with a control; it is independent of this change and reproduces with `--workers=0` too.

Context: this comes out of an ongoing evaluation of the server as a replacement for apache + php-fpm on our Qbix deployments. Happy to adjust style or split this if you would rather it landed differently.