### PR TITLE
harden: use bounded strlcpy/snprintf in u_merkle_cache.h...

### DIFF
--- a/bin/u_merkle_cache.h
+++ b/bin/u_merkle_cache.h
@@ -184,7 +184,7 @@ static void merkle_register_tree(MerkleCache* mc, const char* page_key,
 
     /* Add new tree */
     MerkleTree* tree = &mc->trees[mc->tree_count++];
-    strncpy(tree->page_key, page_key, MERKLE_KEY_LEN - 1);
+    snprintf(tree->page_key, MERKLE_KEY_LEN, "%s", page_key);
     tree->leaf_count = leaf_count;
     memcpy(tree->leaves, leaves, leaf_count * sizeof(MerkleLeaf));
     tree->created = time(NULL);
@@ -205,9 +205,9 @@ static void merkle_register_dep(MerkleCache* mc, const char* stream_key,
         mc->deps = (MerkleDep*)realloc(mc->deps, mc->dep_capacity * sizeof(MerkleDep));
     }
     MerkleDep* d = &mc->deps[mc->dep_count++];
-    strncpy(d->stream_key, stream_key, MERKLE_KEY_LEN - 1);
-    strncpy(d->page_key, page_key, MERKLE_KEY_LEN - 1);
-    strncpy(d->leaf_path, leaf_path, 63);
+    snprintf(d->stream_key, MERKLE_KEY_LEN, "%s", stream_key);
+    snprintf(d->page_key, MERKLE_KEY_LEN, "%s", page_key);
+    snprintf(d->leaf_path, 64, "%s", leaf_path);
 }
 
 /* ── Invalidate a stream key ────────────────────────── */
@@ -250,8 +250,7 @@ static int merkle_invalidate_stream(MerkleCache* mc, const char* stream_key,
             if (strcmp(page_keys_out[k], page_key) == 0) { already = 1; break; }
         }
         if (!already && count < max_out) {
-            strncpy(page_keys_out[count], page_key, MERKLE_KEY_LEN - 1);
-            page_keys_out[count][MERKLE_KEY_LEN - 1] = 0;
+            snprintf(page_keys_out[count], MERKLE_KEY_LEN, "%s", page_key);
             count++;
             mc->pages_invalidated++;
         }
@@ -293,8 +292,7 @@ static int merkle_get_stale_leaves(MerkleCache* mc, const char* page_key,
     int count = 0;
     for (int i = 0; i < tree->leaf_count && count < max_out; i++) {
         if (tree->leaves[i].stale) {
-            strncpy(stale_out[count], tree->leaves[i].path, 63);
-            stale_out[count][63] = 0;
+            snprintf(stale_out[count], 64, "%s", tree->leaves[i].path);
             count++;
         }
     }


### PR DESCRIPTION
## Summary
Harden input handling in `bin/u_merkle_cache.h` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn` |
| **File** | `bin/u_merkle_cache.h:187` |
| **Assessment** | Defensive hardening |

**Description**: Finding triggers whenever there is a strcpy or strncpy used. This is an issue because strcpy does not affirm the size of the destination array and strncpy will not automatically NULL-terminate strings. This can lead to buffer overflows, which can cause program crashes and potentially let an attacker inject code in the program. Fix this by using strcpy_s instead (although note that strcpy_s is an optional part of the C11 standard, and so may not be available).

## Changes
- `bin/u_merkle_cache.h`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
